### PR TITLE
Fix de l'erreur sur les icones dans les dialogues + divers ajouts

### DIFF
--- a/Assets/Asset_in_game/Data/StatsIconCouleurs.asset
+++ b/Assets/Asset_in_game/Data/StatsIconCouleurs.asset
@@ -43,8 +43,8 @@ MonoBehaviour:
   _statVitesseDown: {fileID: -490783285, guid: 0a3ab441b8850b844bbae7eec87e4770, type: 3}
   _statVitesseUp: {fileID: -235407669, guid: 0a3ab441b8850b844bbae7eec87e4770, type: 3}
   _statConviction: {fileID: 1076257092, guid: 0a3ab441b8850b844bbae7eec87e4770, type: 3}
-  _statConvictionUp: {fileID: 1528531112, guid: 0a3ab441b8850b844bbae7eec87e4770, type: 3}
-  _statConvictionDown: {fileID: -362431860, guid: 0a3ab441b8850b844bbae7eec87e4770, type: 3}
+  _statConvictionDown: {fileID: 1528531112, guid: 0a3ab441b8850b844bbae7eec87e4770, type: 3}
+  _statConvictionUp: {fileID: -362431860, guid: 0a3ab441b8850b844bbae7eec87e4770, type: 3}
   _intendionDebuff: {fileID: -440940203, guid: 0a3ab441b8850b844bbae7eec87e4770, type: 3}
   _intentionBuff: {fileID: -457700287, guid: 0a3ab441b8850b844bbae7eec87e4770, type: 3}
   _damage: {fileID: -320632864, guid: 0a3ab441b8850b844bbae7eec87e4770, type: 3}

--- a/Assets/Scenes/BattleScene.unity
+++ b/Assets/Scenes/BattleScene.unity
@@ -15072,7 +15072,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   UIDialogue: {fileID: 1367920561}
-  _fontSize: 36
+  _fontSize: 34
   UIJoueur: {fileID: 1365689808}
   _speakerColor: {r: 0.034487356, g: 0.2924528, b: 0.06442978, a: 0}
   MainText: {fileID: 1172403766}
@@ -16621,7 +16621,7 @@ MonoBehaviour:
   m_charWidthMaxAdj: 0
   m_enableWordWrapping: 1
   m_wordWrappingRatios: 0.4
-  m_overflowMode: 4
+  m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1

--- a/Assets/Scenes/Monde.unity
+++ b/Assets/Scenes/Monde.unity
@@ -3476,6 +3476,7 @@ MonoBehaviour:
         Clairvoyance: 0
         BoughtSpellID: 
   SkillTreeUI: {fileID: 0}
+  _clairvoyanceIconData: {fileID: 11400000, guid: 5fc428ac238ffd8419f88a6cf4269f71, type: 2}
 --- !u!4 &1057772159
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Tutoriel/TutoMonde.unity
+++ b/Assets/Scenes/Tutoriel/TutoMonde.unity
@@ -44222,6 +44222,7 @@ MonoBehaviour:
   StepMapTuto: 0
   IndexEncounter: 0
   ShowSoulConsumation: 0
+  _clairvoyanceIconData: {fileID: 11400000, guid: 5fc428ac238ffd8419f88a6cf4269f71, type: 2}
 --- !u!1 &3187314477433555875
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Combat/JoueurCombat/SpellCombat.cs
+++ b/Assets/Scripts/Combat/JoueurCombat/SpellCombat.cs
@@ -46,11 +46,14 @@ public class SpellCombat : MonoBehaviour
         foreach (var item in Action.Costs)
         {
             if (item.typeCost == TypeCostSpell.volonte)
-                TexteDescription.text += item.Value + "<color=yellow><font-weight=900> V </font-weight></color>";
+                TexteDescription.text += item.Value + "<sprite name=\"" +
+                    ((GameManager.Instance!=null)?GameManager.Instance.StatIcons.StatVolonte.name : TutoManager.Instance.StatIcons.StatVolonte.name) + "\">";
             if (item.typeCost == TypeCostSpell.radiance)
-                TexteDescription.text += item.Value + "<color=red><font-weight=900> R </font-weight></color>";
+                TexteDescription.text += item.Value + "<sprite name=\"" +
+                    ((GameManager.Instance != null) ? GameManager.Instance.StatIcons.StatRadiance.name : TutoManager.Instance.StatIcons.StatRadiance.name) + "\">";
             if (item.typeCost == TypeCostSpell.conscience)
-                TexteDescription.text += item.Value + "<color=green><font-weight=900> C </font-weight></color>";
+                TexteDescription.text += item.Value + "<sprite name=\"" +
+                    ((GameManager.Instance != null) ? GameManager.Instance.StatIcons.StatConscience.name : TutoManager.Instance.StatIcons.StatConscience.name) + "\">";
         }
 
         TexteDescription.text += "\n";
@@ -142,11 +145,14 @@ public class SpellCombat : MonoBehaviour
         foreach (var item in Action.Costs)
         {
             if (item.typeCost == TypeCostSpell.volonte)
-                TexteDescription.text += item.Value + "<color=yellow><font-weight=900> V </font-weight></color>";
+                TexteDescription.text += item.Value + "<sprite name=\"" +
+                    ((GameManager.Instance != null) ? GameManager.Instance.StatIcons.StatVolonte.name : TutoManager.Instance.StatIcons.StatVolonte.name) + "\">";
             if (item.typeCost == TypeCostSpell.radiance)
-                TexteDescription.text += item.Value + "<color=red><font-weight=900> R </font-weight></color>";
+                TexteDescription.text += item.Value + "<sprite name=\"" +
+                    ((GameManager.Instance != null) ? GameManager.Instance.StatIcons.StatRadiance.name : TutoManager.Instance.StatIcons.StatRadiance.name) + "\">";
             if (item.typeCost == TypeCostSpell.conscience)
-                TexteDescription.text += item.Value + "<color=green><font-weight=900> C </font-weight></color>";
+                TexteDescription.text += item.Value + "<sprite name=\"" +
+                    ((GameManager.Instance != null) ? GameManager.Instance.StatIcons.StatConscience.name : TutoManager.Instance.StatIcons.StatConscience.name) + "\">";
         }
 
         TexteDescription.text += "\n";

--- a/Assets/Scripts/Dialogue/ClairvoyanceIconData.cs
+++ b/Assets/Scripts/Dialogue/ClairvoyanceIconData.cs
@@ -76,9 +76,9 @@ public class ClairvoyanceIconData : ScriptableObject
     [SerializeField]
     private Sprite _statConviction;
     [SerializeField]
-    private Sprite _statConvictionUp;
-    [SerializeField]
     private Sprite _statConvictionDown;
+    [SerializeField]
+    private Sprite _statConvictionUp;
 
     [SerializeField]
     private Sprite _intendionDebuff;

--- a/Assets/Scripts/Dialogue/ClairvoyanceIconStatEnum.cs
+++ b/Assets/Scripts/Dialogue/ClairvoyanceIconStatEnum.cs
@@ -21,5 +21,7 @@ public enum ClairvoyanceIconStatEnum
     VolonteUp,
     VolonteDown,
     Degats,
-    Soins
+    Soins,
+    TensionUp,
+    TensionDown
 }

--- a/Assets/Scripts/Dialogue/DialogueManager.cs
+++ b/Assets/Scripts/Dialogue/DialogueManager.cs
@@ -118,7 +118,7 @@ public class DialogueManager : MonoBehaviour
     private void GetAnswerList()
     {
         _displayedClairvoyanceStats = new Dictionary<ClairvoyanceIconStatEnum, bool>();
-        bool[] displayed = new bool[Enum.GetValues(typeof(ClairvoyanceIconStatEnum)).Length];
+        
         TextDisplayer textDisplayer = MainText.GetComponent<TextDisplayer>();
         if (textDisplayer != null)
         {
@@ -188,9 +188,9 @@ public class DialogueManager : MonoBehaviour
                 Reponse[i].text = response;
                 ReponseGO[i].SetActive(true);
                 //Réponse[i].GetComponent<TextAnimation>().LaunchAnim();
-
                 if (ManagerBattle.player.Stat.Clairvoyance >= currentPossibleResponseList[i].SeuilClairvoyanceStat)
                 {
+                    bool[] displayed = new bool[Enum.GetValues(typeof(ClairvoyanceIconStatEnum)).Length];
                     ShowConsequenceForAnswer(i, ref displayed);
                 }
             }
@@ -267,10 +267,10 @@ public class DialogueManager : MonoBehaviour
 
         switch (effet.TypeEffet)
         {
+            case TypeEffet.AugmentationBrutFA:
             case TypeEffet.AttaqueFADebuff:
-
-                color = (effet.Cible == Cible.joueur) ? Color.red : Color.green;
-                if (effet.Cible == Cible.joueur)
+                if ((effet.Cible == Cible.joueur && effet.ValeurBrut < 0)
+                    || (effet.Cible != Cible.joueur && effet.ValeurBrut > 0))
                 {
                     if (!displayed[(int) ClairvoyanceIconStatEnum.ForceDameDown])
                     {
@@ -295,10 +295,9 @@ public class DialogueManager : MonoBehaviour
 
                 break;
             case TypeEffet.AugmentationPourcentageFACible:
-            case TypeEffet.AugmentationBrutFA:
             case TypeEffet.AugmentationPourcentageFA:
-                color = (effet.Cible == Cible.joueur) ? Color.green : Color.red;
-                if (effet.Cible != Cible.joueur)
+                if ((effet.Cible == Cible.joueur && effet.Pourcentage < 0)
+                    || (effet.Cible != Cible.joueur && effet.Pourcentage > 0))
                 {
                     if (!displayed[(int) ClairvoyanceIconStatEnum.ForceDameDown])
                     {
@@ -323,8 +322,8 @@ public class DialogueManager : MonoBehaviour
 
                 break;
             case TypeEffet.RadianceMax:
-                color = (effet.ValeurBrut > 0) ? Color.green : Color.red;
-                if (effet.ValeurBrut < 0)
+                if ((effet.Cible == Cible.joueur && effet.ValeurBrut < 0)
+                    || (effet.Cible != Cible.joueur && effet.ValeurBrut > 0))
                 {
                     if (!displayed[(int) ClairvoyanceIconStatEnum.RadianceDown])
                     {
@@ -349,8 +348,8 @@ public class DialogueManager : MonoBehaviour
 
                 break;
             case TypeEffet.Resilience:
-                color = (effet.ValeurBrut > 0) ? Color.green : Color.red;
-                if (effet.ValeurBrut < 0)
+                if ((effet.Cible == Cible.joueur && effet.ValeurBrut < 0)
+                    || (effet.Cible != Cible.joueur && effet.ValeurBrut > 0))
                 {
                     if (!displayed[(int) ClairvoyanceIconStatEnum.ResilienceDown])
                     {
@@ -375,8 +374,8 @@ public class DialogueManager : MonoBehaviour
 
                 break;
             case TypeEffet.Clairvoyance:
-                color = (effet.ValeurBrut > 0) ? Color.green : Color.red;
-                if (effet.ValeurBrut < 0)
+                if ((effet.Cible == Cible.joueur && effet.ValeurBrut < 0)
+                    || (effet.Cible != Cible.joueur && effet.ValeurBrut > 0))
                 {
                     if (!displayed[(int) ClairvoyanceIconStatEnum.ClairvoyaneDown])
                     {
@@ -401,8 +400,8 @@ public class DialogueManager : MonoBehaviour
 
                 break;
             case TypeEffet.Vitesse:
-                color = (effet.ValeurBrut > 0) ? Color.green : Color.red;
-                if (effet.ValeurBrut < 0)
+                if ((effet.Cible == Cible.joueur && effet.ValeurBrut < 0)
+                    || (effet.Cible != Cible.joueur && effet.ValeurBrut > 0))
                 {
                     if (!displayed[(int) ClairvoyanceIconStatEnum.VitesseDown])
                     {
@@ -427,8 +426,8 @@ public class DialogueManager : MonoBehaviour
 
                 break;
             case TypeEffet.Conviction:
-                color = (effet.ValeurBrut > 0) ? Color.green : Color.red;
-                if (effet.ValeurBrut < 0)
+                if ((effet.Cible == Cible.joueur && effet.ValeurBrut < 0)
+                    || (effet.Cible != Cible.joueur && effet.ValeurBrut > 0))
                 {
                     if (!displayed[(int) ClairvoyanceIconStatEnum.ConvictionDown])
                     {
@@ -453,8 +452,8 @@ public class DialogueManager : MonoBehaviour
 
                 break;
             case TypeEffet.Conscience:
-                color = (effet.ValeurBrut > 0) ? Color.green : Color.red;
-                if (effet.ValeurBrut < 0)
+                if ((effet.Cible == Cible.joueur && effet.ValeurBrut < 0)
+                    || (effet.Cible != Cible.joueur && effet.ValeurBrut > 0))
                 {
                     if (!displayed[(int) ClairvoyanceIconStatEnum.ConscienceDown])
                     {
@@ -478,13 +477,36 @@ public class DialogueManager : MonoBehaviour
                 }
 
                 break;
-            case TypeEffet.DegatPVMax:
-            case TypeEffet.DegatsBrut:
             case TypeEffet.DegatsBrutConsequence:
+                if ((effet.Cible == Cible.joueur && effet.ValeurBrut < 0)
+                    || (effet.Cible != Cible.joueur && effet.ValeurBrut > 0))
+                {
+                    if (!displayed[(int)ClairvoyanceIconStatEnum.Degats])
+                    {
+                        displayed[(int)ClairvoyanceIconStatEnum.Degats] = true;
+                        strb.Append((_clairvoyanceIconData.Damage != null)
+                            ? _clairvoyanceIconData.Damage.name
+                            : "DMG");
+                    }
+                    else return "";
+                }
+                else
+                {
+                    if (!displayed[(int)ClairvoyanceIconStatEnum.ConvictionUp])
+                    {
+                        displayed[(int)ClairvoyanceIconStatEnum.ConvictionUp] = true;
+                        strb.Append((_clairvoyanceIconData.StatConvictionUp != null)
+                            ? _clairvoyanceIconData.StatConvictionUp.name
+                            : "Con");
+                    }
+                    else return "";
+                }
+
+                break;
             case TypeEffet.Volonte:
             case TypeEffet.VolonteMax:
-                color = (effet.ValeurBrut > 0) ? Color.green : Color.red;
-                if (effet.ValeurBrut < 0)
+                if ((effet.Cible == Cible.joueur && effet.ValeurBrut < 0)
+                    || (effet.Cible != Cible.joueur && effet.ValeurBrut > 0))
                 {
                     if (!displayed[(int) ClairvoyanceIconStatEnum.VolonteDown])
                     {
@@ -508,18 +530,45 @@ public class DialogueManager : MonoBehaviour
                 }
 
                 break;
-            case TypeEffet.DegatsForceAme:
-            case TypeEffet.Colere:
-            case TypeEffet.AugmentFADernierDegatsSubi:
-            case TypeEffet.MultiplDegat:
-            case TypeEffet.MultiplSoin:
-            case TypeEffet.MultiplDef:
             case TypeEffet.TensionStep:
             case TypeEffet.TensionValue:
             case TypeEffet.TensionGainAttaqueValue:
             case TypeEffet.TensionGainDebuffValue:
             case TypeEffet.TensionGainSoinValue:
             case TypeEffet.TensionGainDotValue:
+                if ((effet.Cible == Cible.joueur && effet.ValeurBrut < 0)
+                   || (effet.Cible != Cible.joueur && effet.ValeurBrut > 0))
+                {
+                    if (!displayed[(int)ClairvoyanceIconStatEnum.TensionDown])
+                    {
+                        displayed[(int)ClairvoyanceIconStatEnum.TensionDown] = true;
+                        strb.Append((_clairvoyanceIconData.StatTensionDown != null)
+                            ? _clairvoyanceIconData.StatTensionDown.name
+                            : "FA");
+                    }
+                    else return "";
+                }
+                else
+                {
+                    if (!displayed[(int)ClairvoyanceIconStatEnum.TensionUp])
+                    {
+                        displayed[(int)ClairvoyanceIconStatEnum.TensionUp] = true;
+                        strb.Append((_clairvoyanceIconData.StatTensionUp != null)
+                            ? _clairvoyanceIconData.StatTensionUp.name
+                            : "TENS");
+                    }
+                    else return "TENS";
+                }
+
+                break;
+            case TypeEffet.DegatPVMax:
+            case TypeEffet.DegatsBrut:
+            case TypeEffet.DegatsForceAme:
+            case TypeEffet.Colere:
+            case TypeEffet.AugmentFADernierDegatsSubi:
+            case TypeEffet.MultiplDegat:
+            case TypeEffet.MultiplSoin:
+            case TypeEffet.MultiplDef:
             case TypeEffet.ConscienceMax:
             case TypeEffet.Soin:
             case TypeEffet.SoinFA:

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -38,6 +38,10 @@ public class GameManager : MonoBehaviour {
     [Header("Data")]
     public GameData loadedData;
     public SkillTreePrinter SkillTreeUI;
+    [SerializeField]
+    private ClairvoyanceIconData _clairvoyanceIconData;
+
+    public ClairvoyanceIconData StatIcons { get => _clairvoyanceIconData; }
 
     private void Awake() {
         if (Instance != null)

--- a/Assets/Scripts/GameManager.cs.meta
+++ b/Assets/Scripts/GameManager.cs.meta
@@ -3,7 +3,19 @@ guid: 6f54bdcc530a9324a97e918fc8cbf214
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
-  defaultReferences: []
+  defaultReferences:
+  - rm: {instanceID: 0}
+  - pmm: {instanceID: 0}
+  - BattleMan: {instanceID: 0}
+  - TutoManager: {instanceID: 0}
+  - AleaMan: {instanceID: 0}
+  - OldAutelMan: {instanceID: 0}
+  - StatMan: {instanceID: 0}
+  - classSO: {instanceID: 0}
+  - playerStat: {instanceID: 0}
+  - passifRules: {instanceID: 0}
+  - SkillTreeUI: {instanceID: 0}
+  - _clairvoyanceIconData: {instanceID: 0}
   executionOrder: -20
   icon: {instanceID: 0}
   userData: 

--- a/Assets/Scripts/Traduction/Analyzer.cs
+++ b/Assets/Scripts/Traduction/Analyzer.cs
@@ -300,6 +300,10 @@ public class Analyzer : MonoBehaviour
                     strb.Append((_clairvoyanceIconData.StatConscience == null) ? "CONS" : _clairvoyanceIconData.StatConscience.name);
                 else if (attributes[TradAttribute.value].Equals("TEN", System.StringComparison.InvariantCultureIgnoreCase))
                     strb.Append((_clairvoyanceIconData.StatTension == null) ? "TEN" : _clairvoyanceIconData.StatTension.name);
+                else if (attributes[TradAttribute.value].Equals("VOL", System.StringComparison.InvariantCultureIgnoreCase))
+                    strb.Append((_clairvoyanceIconData.StatVolonte == null) ? "VOL" : _clairvoyanceIconData.StatVolonte.name);
+                else if (attributes[TradAttribute.value].Equals("DMG", System.StringComparison.InvariantCultureIgnoreCase))
+                    strb.Append((_clairvoyanceIconData.Damage == null) ? "DMG" : _clairvoyanceIconData.Damage.name);
                 else
                     strb.Append(attributes[TradAttribute.value]);
                 strb.Append("\">");

--- a/Assets/Scripts/Traduction/TradManager.cs
+++ b/Assets/Scripts/Traduction/TradManager.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Text;
 using UnityEngine;
 using yutokun;

--- a/Assets/Scripts/Tutoriel/TutoManager.cs
+++ b/Assets/Scripts/Tutoriel/TutoManager.cs
@@ -33,6 +33,11 @@ public class TutoManager : MonoBehaviour
     private int _indEncounter = 0;
     private TutoMondeManager _tutoMondeManager;
 
+    [SerializeField]
+    private ClairvoyanceIconData _clairvoyanceIconData;
+
+    public ClairvoyanceIconData StatIcons { get => _clairvoyanceIconData; }
+
     private void Awake()
     {
         if (instance == null)


### PR DESCRIPTION
- Fix de l'erreur sur les icones de clairvoyance dans le dialogue qui s'affichait de la mauvaise couleur. fix #53 
- Ajouts des icones de clairvoyance pour la volonté et la tension dans les dialogues.
- Ajout de l'icône de volonté, de conscience et de radiance dans le descriptions des compétences pour les coûts.