### PR TITLE
Warning cleanups

### DIFF
--- a/Assets/Scripts/Combat/Passifs/ImplementedPassif/PassiveEffect/StatPerConsciencePassive.cs
+++ b/Assets/Scripts/Combat/Passifs/ImplementedPassif/PassiveEffect/StatPerConsciencePassive.cs
@@ -19,7 +19,6 @@ public class StatPerConsciencePassive : AbstractPassive, IPassiveEffect
     private List<StatToModif> _statToModif;
     private JoueurStat _joueurStat;
     private int modificator = 1;
-    private bool _isInit = false;
 
     private int GetMainStatValue(CharacterStat charStat) => _mainStat switch
     {
@@ -32,7 +31,6 @@ public class StatPerConsciencePassive : AbstractPassive, IPassiveEffect
         _joueurStat = stat;
         stat.OnConscienceIncrease += Apply;
         stat.OnConscienceDecrease += Apply;
-        _isInit = true;
     }
     private void OnDestroy()
     {

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -380,19 +380,19 @@ public class GameManager : MonoBehaviour
         {
             case TypeRoom.ENCOUNTER:
                 return UnityEngine.Random.Range(0, EncounterSet.EncounterNeutralList.Count);
-                break;
+
             case TypeRoom.CLASS_ENCOUNTER:
                 return UnityEngine.Random.Range(0, EncounterSet.EncounterClassList.Count);
-                break;
+
             case TypeRoom.ELITE:
                 return UnityEngine.Random.Range(0, EncounterSet.EncounterEliteList.Count);
-                break;
+
             case TypeRoom.CLASS_ELITE:
                 return UnityEngine.Random.Range(0, EncounterSet.EncounterClassEliteList.Count);
-                break;
+
             case TypeRoom.BOSS:
                 return UnityEngine.Random.Range(0, EncounterSet.EncounterBossList.Count);
-                break;
+
             default: return 0;
         }
     }

--- a/Assets/Scripts/GeneralPopUp.cs
+++ b/Assets/Scripts/GeneralPopUp.cs
@@ -11,7 +11,6 @@ public class GeneralPopUp : MonoBehaviour
 {
     private static GeneralPopUp instance = null;
     public static GeneralPopUp Instance = instance;
-    private Canvas activeCanvas = null;
     [Header("PopUp Window")]
     [SerializeField] private GameObject pupUpWindowPrefab;
     [SerializeField] private AnimationCurve movmentCurve;

--- a/Assets/Scripts/Item/Capacite/Effet.cs
+++ b/Assets/Scripts/Item/Capacite/Effet.cs
@@ -101,18 +101,9 @@ public class Effet : ScriptableObject
                 damageAmount += Mathf.FloorToInt(valueToChange * caster .MultiplDegat);
                 break;
             case TypeEffet.RadianceMax:
-
-                //damageAmount = Mathf.FloorToInt((Pourcentage / 100f) * caster.RadianceMaxOriginal); ;//Mathf.FloorToInt((Pourcentage / 100f) * ((cible.Radiance / cible.RadianceMax) * cible.RadianceMaxOriginal));
-                if (Cible == null)
-                {
-                    int addAmount = (int)(caster.RadianceMax * Pourcentage * .01f);
-                    damageAmount = caster.RadianceMax + addAmount;
-                }
-                else
-                {
-                    int addAmount = (int)(cible.RadianceMax * Pourcentage * .01f);
-                    damageAmount = cible.RadianceMax + addAmount;
-                }
+                int radianceMax = cible?.RadianceMax ?? caster.RadianceMax;
+                int addAmount = (int)(radianceMax * Pourcentage * .01f);
+                damageAmount = radianceMax + addAmount;
                 break;
            
             case TypeEffet.DegatPVMax:

--- a/Assets/Scripts/TargetableTurnOrderItem.cs
+++ b/Assets/Scripts/TargetableTurnOrderItem.cs
@@ -32,7 +32,8 @@ public class TargetableTurnOrderItem : MonoBehaviour
 
     private void OnMouseDown()
     {
-        return;//Temp
+        //TODO do something?
+        return;
         if (Ciblage == null) return;
         RaiseEvent();
         Ciblage.SetActive(false);

--- a/Assets/Scripts/TargetableTurnOrderItem.cs
+++ b/Assets/Scripts/TargetableTurnOrderItem.cs
@@ -32,10 +32,10 @@ public class TargetableTurnOrderItem : MonoBehaviour
 
     private void OnMouseDown()
     {
-        //TODO do something?
         return;
-        if (Ciblage == null) return;
-        RaiseEvent();
-        Ciblage.SetActive(false);
+        //TODO do something?
+        //if (Ciblage == null) return;
+        //RaiseEvent();
+        //Ciblage.SetActive(false);
     }
 }

--- a/Assets/Scripts/Traduction/Analyzer.cs
+++ b/Assets/Scripts/Traduction/Analyzer.cs
@@ -266,7 +266,7 @@ public class Analyzer : MonoBehaviour
                 case AnalexState.AttributeState:
                     Debug.Log("perdu");
                     return string.Empty;
-                    break;
+                    
                 case AnalexState.ValueState:
                     currentAttribute.Value = ReadValue(stringTab[currentIndex]);
                     currenAtttributes.Add(currentAttribute);

--- a/Assets/Scripts/Tutoriel/TutoManager.cs
+++ b/Assets/Scripts/Tutoriel/TutoManager.cs
@@ -26,7 +26,6 @@ public class TutoManager : MonoBehaviour
 
 
     public bool ShowSoulConsumation;
-    private int _indEncounter = 0;
     [Header("Datas")] [SerializeField] private ClairvoyanceIconData _clairvoyanceIconData;
     [SerializeField] private Souvenir _souvenirToLoot;
     [field:SerializeField] public Transform SouvenirPosTuto { get; private set; }


### PR DESCRIPTION
Lowered the amount of warning at compilation by removing useless breaks and unused variables and cleaning up unreachable code.
And there's a fix for RadianceMax effect with no target (cible is null)