### PR TITLE
First combat fix

### DIFF
--- a/Assets/Scripts/Combat/Animation/WaitEndAttack.cs
+++ b/Assets/Scripts/Combat/Animation/WaitEndAttack.cs
@@ -8,8 +8,8 @@ public class WaitEndAttack : StateMachineBehaviour
     {
         //After animation, reactivate spells.
         if (GameManager.Instance != null)
-            GameManager.Instance.BattleMan.player.ActivateSpells();
+            GameManager.Instance.BattleMan.ActivatePlayer();
         else
-            TutoManager.Instance.BattleManager.player.ActivateSpells();
+            TutoManager.Instance.BattleManager.ActivatePlayer();
     }
 }

--- a/Assets/Scripts/Combat/BattleManager.cs
+++ b/Assets/Scripts/Combat/BattleManager.cs
@@ -1238,6 +1238,14 @@ public class BattleManager : MonoBehaviour
         StopCoroutine(Target);
         StartCoroutine(Target, IdSpell);
     }
+    public void StopTargeting()
+    {
+        StopCoroutine(Target);
+        foreach (var item in EnemyScripts)
+        {
+            item.EndTargetingMode();
+        }
+    }
 
     private IEnumerator Targeting(int IdSpell)
     {

--- a/Assets/Scripts/Combat/BattleManager.cs
+++ b/Assets/Scripts/Combat/BattleManager.cs
@@ -579,6 +579,13 @@ public class BattleManager : MonoBehaviour
         //turnOrderUIManager.GenerateTurnItems(IdOrder);
     }
 
+    public void ActivatePlayer()
+    {
+        var i = EnemyScripts.Where(x=>x.Stat.Radiance > 0).Count();
+        if (i > 0)
+            player.ActivateSpells();
+    }
+
     #endregion Phase
 
     #region Turn
@@ -1195,6 +1202,7 @@ public class BattleManager : MonoBehaviour
                 }
                 else
                 {
+                    player.DesactivateSpells();
                     StartCoroutine("GatherEssence");
                 }
 

--- a/Assets/Scripts/Combat/Behavior/JoueurBehavior.cs
+++ b/Assets/Scripts/Combat/Behavior/JoueurBehavior.cs
@@ -328,6 +328,8 @@ public class JoueurBehavior : CombatBehavior<JoueurStat>
 
         IsTurn = false;
         DesactivateSpells();
+        SelectedSpell = null;
+        _refBattleMan.StopTargeting();
         _playedTurn++;
         EndTurnBM();
     }
@@ -420,7 +422,7 @@ public class JoueurBehavior : CombatBehavior<JoueurStat>
         }
         
         if (needCible)
-        TakeTarget(SelectedSpell.IDSpell);
+            TakeTarget(SelectedSpell.IDSpell);
         else
         {
             _refBattleMan.idTarget = 0;
@@ -439,7 +441,6 @@ public class JoueurBehavior : CombatBehavior<JoueurStat>
         {
             spell.GetComponent<SpellCombat>().selectedSpell.SetActive(false);
         }
-
         EndTurnButton.interactable = false;
         _highlightComponant.DisableHighlightingBetweenTarget();
     }


### PR DESCRIPTION
- le bouton fin de tour cliquable qd le combat est finit,
- (un crash du jeu si on cliquait fin de tour un peu vite),
- le spell qui restait selectionné entre deux tour (ce qui permettait de jouer pendant le tour ennemi